### PR TITLE
legal(license): Set repository spdx from LICENSE

### DIFF
--- a/.repository/license.spdx
+++ b/.repository/license.spdx
@@ -1,0 +1,8 @@
+SPDXVersion: SPDX-2.0
+DataLicense: MIT
+Creator: Jonathan R. Beverly
+Created: 2019
+PackageName: cardboardci/docker-bats
+PackageOriginator: Jonathan R. Beverly
+PackageHomePage: https://github.com/cardboardci/docker-bats
+PackageLicenseDeclared: MIT


### PR DESCRIPTION
Sets the repository spdx file (in `.repository`) based on the LICENSE.md

This is intended to make it easier to apply licensing stamps on resources through automation. The spdx convention can be applied onto artifacts (like tarballs/docker images/etc), and having them in a commonly accessible location like `.repository/license.spdx` makes it easier for any build automation to take advantage of it.